### PR TITLE
Update ksiegarnia.css

### DIFF
--- a/css/ksiegarnia.css
+++ b/css/ksiegarnia.css
@@ -32,9 +32,9 @@
     padding: 0;
     margin: 7px 0 7px 0;
 }
-.helion_ksiegarnia .helion-polecane p, span, a,
-.helion_ksiegarnia .helion-nowosc p, span, a,
-.helion_ksiegarnia .helion-bestseller p, span, a {
+.helion_ksiegarnia .helion-polecane p, .helion_ksiegarnia .helion-polecane span, .helion_ksiegarnia .helion-polecane a,
+.helion_ksiegarnia .helion-nowosc p, .helion_ksiegarnia .helion-polecane span, .helion_ksiegarnia .helion-polecane a,
+.helion_ksiegarnia .helion-bestseller p, .helion_ksiegarnia .helion-polecane span, .helion_ksiegarnia .helion-polecane a {
     font-size: 12px;
 }
 


### PR DESCRIPTION
Lines 35-37, without putting parrents there is an overwrite of font size for "span" and "a" elements. When ksiegarnia.css is loaded as one of the latests css it breaks the styles of the template for mentioned tags.
